### PR TITLE
fix: replace update with upsert for TM submissions

### DIFF
--- a/src/lib/scripts/submit.ts
+++ b/src/lib/scripts/submit.ts
@@ -13,14 +13,23 @@ export async function submitTeamMatch(
     auto_actions: Omit<AutoActionData, "id" | "team_match">[],
     tags: { name: string; category: string }[]
 ) {
-    const { id_num: id } = await prisma.teamMatch.update({
+    const { id_num: id } = await prisma.teamMatch.upsert({
         where: {
             id_key: {
                 match_key: tm.match_key,
                 team_key: tm.team_key,
             },
         },
-        data: {
+        create: {
+            ...tm,
+            TeleActions: {
+                create: tele_actions,
+            },
+            AutoActions: {
+                create: auto_actions,
+            },
+        },
+        update: {
             ...tm,
             TeleActions: {
                 create: tele_actions,


### PR DESCRIPTION
## Description

Having this be update has just randomly been causing issues, occasionally voiding some team_matches which have no reason not to work as far as I know, and if we want quantitative prescouting, we wouldn't be able to preload it into the database