### PR TITLE
Remove Pairwise menu for prescouting

### DIFF
--- a/src/routes/pairwise/+page.server.ts
+++ b/src/routes/pairwise/+page.server.ts
@@ -7,7 +7,8 @@ export const load: PageServerLoad = async ({ params: _, url }) => {
     const categories = ["coral"]
 
     const event_key = (await prisma.eventState.findFirst({}))?.event_key
-    if (event_key === undefined) return redirect(307, "/home")
+    if (event_key === undefined || event_key.slice(4, 7) === "pre")
+        return redirect(307, "/home")
 
     const team_matches = await prisma.teamMatch.findMany({
         where: {


### PR DESCRIPTION
## Description

It wouldn't be informative, given the fact that users will be scouting the same robot repeatedly, and won't even work currently due to how submissions are sorted (users will always just compare teams that they have scouted all matches of)